### PR TITLE
Restrict CI push trigger to main/master, run on pull_request too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main", "master"]
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This mirrors the change already applied to `membrane_hackney_plugin`:

- Adds a `pull_request:` trigger to `ci.yml`, so PRs (including from forks) run CI. This is now safe org-wide since the org setting requiring manual approval for workflow runs from outside collaborators' forks has been enabled.
- Restricts the `push` trigger to `main`/`master` only, so a PR from a branch in this repo does not trigger CI twice (once via `push` on the branch, once via `pull_request`).

Only the `on:` block was touched; job definitions are unchanged.